### PR TITLE
Fix segfault in ocp

### DIFF
--- a/pkgs/opencascade-occt/default.nix
+++ b/pkgs/opencascade-occt/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchpatch,
   stdenv,
   fetchurl,
   cmake,
@@ -19,7 +20,6 @@
   freeimage,
   enableFreeimage ? false,
 }:
-
 stdenv.mkDerivation rec {
   pname = "opencascade-occt";
   version = "7.7.2";
@@ -30,6 +30,13 @@ stdenv.mkDerivation rec {
     url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=${commit};sf=tgz";
     sha256 = "sha256-M0G/pJuxsJu5gRk0rIgC173/XxI1ERpmCtWjgr/0dyY=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/conda-forge/occt-feedstock/00ff0f68644d9582a4c30c01220e7de0f934d427/recipe/patches/blobfish.patch";
+      sha256 = "sha256-5tqkx7W7VBw7qaseFgwBENKbGQ0iUYEL6SJHwGI9L/g=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/python/build123d/default.nix
+++ b/pkgs/python/build123d/default.nix
@@ -63,8 +63,6 @@ buildPythonPackage {
     "test_single_object"
     # Overly strict test
     "test_version"
-    # TODO: why does this segfault
-    "test_ellipse_rotation"
   ];
 
 }

--- a/pkgs/python/cadquery/default.nix
+++ b/pkgs/python/cadquery/default.nix
@@ -52,15 +52,6 @@ buildPythonPackage {
     typish
   ];
 
-  disabledTests = [
-    # TODO: why do these segfault?
-    "test_colors_assy0"
-    "test_colors_assy1"
-    "test_colors_fused_assy"
-    "testExtrude"
-    "testDXF"
-  ];
-
   nativeCheckInputs = [
     pytestCheckHook
     ipython

--- a/pkgs/python/cq-warehouse/default.nix
+++ b/pkgs/python/cq-warehouse/default.nix
@@ -33,12 +33,4 @@ buildPythonPackage {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  disabledTests = [
-    "test_five_sprocket_chain"
-    "test_missing_link"
-    "test_oblique_plane"
-    "test_assemble_chain_transmission"
-    "test_make_link"
-  ];
-
 }

--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,6 @@
 Nix expressions to build [OCP](https://github.com/CadQuery/OCP) and related projects.
 Inspired by [vinszent/cq-flake](https://github.com/vinszent/cq-flake).
 
-## Pardon the dust
-
-OCP and CadQuery build; albeit with a couple failing tests. Cleaning up a
-couple of things and adding docs are next on the docket.
-
 ## Usage
 
 If you just want to start up a `cq-editor` session right now you can do that with:


### PR DESCRIPTION
Turns out the segfault is fixed by applying the [blobfish patch](https://github.com/conda-forge/occt-feedstock/blob/f95e88194e0a98ea1e92ff35cb4911af642e19aa/recipe/patches/blobfish.patch). I was mistakenly under the impression that the new patches in [occt-feedstock](https://github.com/conda-forge/occt-feedstock/tree/main/recipe/patches) would also work but that does not seem to be the case.

closes #2