### PR TITLE
cq-gridfinity: init at 0.5.6

### DIFF
--- a/pkgs/python/cq-gridfinity/default.nix
+++ b/pkgs/python/cq-gridfinity/default.nix
@@ -1,0 +1,33 @@
+{
+  fetchFromGitHub,
+  buildPythonPackage,
+  cadquery,
+  cq-kit,
+  setuptools,
+  pytestCheckHook,
+}:
+let
+  version = "0.5.6";
+in
+buildPythonPackage {
+  pname = "cq-gridfinity";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "michaelgale";
+    repo = "cq-gridfinity";
+    rev = "v.${version}";
+    hash = "sha256-P5fXTs2ImNI5Bt4DwNHTJPfFLV0Q8XIKu9vHgmVDnpQ=";
+  };
+
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    cq-kit
+    cadquery
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+}

--- a/pkgs/python/overlay.nix
+++ b/pkgs/python/overlay.nix
@@ -7,6 +7,7 @@ final: prev: {
   build123d = final.callPackage ./build123d { };
   cadquery = final.callPackage ./cadquery { };
   casadi = final.toPythonModule (casadi.override { pythonSupport = true; });
+  cq-gridfinity = final.callPackage ./cq-gridfinity { };
   cq-kit = final.callPackage ./cq-kit { };
   cq-warehouse = final.callPackage ./cq-warehouse { };
   libclang = prev.libclang.override { llvmPackages = llvmPackages_15; };


### PR DESCRIPTION
Initializes [cq-gridfinity](https://github.com/michaelgale/cq-gridfinity)

> A python library to build parameterized gridfinity compatible objects such a baseplates and boxes. 

at version 0.5.6
