### PR TITLE
cq-gears: init at b621d97

### DIFF
--- a/pkgs/python/cq-gears/default.nix
+++ b/pkgs/python/cq-gears/default.nix
@@ -1,0 +1,36 @@
+{
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  cadquery,
+  numpy,
+  pytestCheckHook,
+}:
+let
+  rev = "b621d97";
+in
+buildPythonPackage {
+  pname = "cq-gears";
+  version = rev;
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "meadiode";
+    repo = "cq_gears";
+    hash = "sha256-d5GoRZH5PSYDFGVobuuKESk3XKqf5ty/SxbxWy0x8JQ=";
+  };
+
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    cadquery
+    numpy
+  ];
+
+  # TODO: the tests fail due to some basic module importing failure...
+  doCheck = false;
+
+  nativeCheckInputs = [ pytestCheckHook ];
+}

--- a/pkgs/python/overlay.nix
+++ b/pkgs/python/overlay.nix
@@ -7,6 +7,7 @@ final: prev: {
   build123d = final.callPackage ./build123d { };
   cadquery = final.callPackage ./cadquery { };
   casadi = final.toPythonModule (casadi.override { pythonSupport = true; });
+  cq-gears = final.callPackage ./cq-gears { };
   cq-kit = final.callPackage ./cq-kit { };
   cq-warehouse = final.callPackage ./cq-warehouse { };
   libclang = prev.libclang.override { llvmPackages = llvmPackages_15; };


### PR DESCRIPTION
Initalizes (cq-gears)[https://github.com/meadiode/cq_gears]

> CadQuery based involute gear parametric modelling 

at rev `b621d97`. Currently the tests don't run, doesn't look like a hard fix
just haven't gotten to it yet.
