### PR TITLE
yacv

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -20,4 +20,6 @@ final: prev: {
     (final.callPackage python-overlay { })
   ];
 
+  yacv-frontend = final.callPackage ./yacv-frontend { };
+
 }

--- a/pkgs/python/overlay.nix
+++ b/pkgs/python/overlay.nix
@@ -4,8 +4,8 @@
   ocp,
 }:
 final: prev: {
-  build123d = final.callPackage ./build123d { };
   bd-warehouse = final.callPackage ./bd-warehouse { };
+  build123d = final.callPackage ./build123d { };
   cadquery = final.callPackage ./cadquery { };
   casadi = final.toPythonModule (casadi.override { pythonSupport = true; });
   cq-gridfinity = final.callPackage ./cq-gridfinity { };
@@ -21,4 +21,5 @@ final: prev: {
   spyder-kernels = final.callPackage ./spyder-kernels { };
   svgpathtools = final.callPackage ./svgpathtools { };
   trianglesolver = final.callPackage ./trianglesolver { };
+  yacv-server = final.callPackage ./yacv-server { };
 }

--- a/pkgs/python/yacv-server/default.nix
+++ b/pkgs/python/yacv-server/default.nix
@@ -1,0 +1,36 @@
+{
+  fetchFromGitHub,
+  buildPythonPackage,
+  poetry-core,
+  build123d,
+  pillow,
+  pygltflib,
+}:
+let
+  version = "0.9.0";
+  owner = "yeicor-3d";
+  repo = "yet-another-cad-viewer";
+  rev = "v${version}";
+in
+
+buildPythonPackage {
+  pname = "yacv_server";
+  inherit version;
+
+  src = fetchFromGitHub {
+    inherit owner repo rev;
+    hash = "sha256-aDQQAHOLN5GEQj3Bg/MVdffbdeR9Pp0LJx5u36+b1Ec=";
+  };
+
+  pyproject = true;
+
+  SKIP_BUILD_FRONTEND = "1";
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    build123d
+    pillow
+    pygltflib
+  ];
+}

--- a/pkgs/yacv-frontend/default.nix
+++ b/pkgs/yacv-frontend/default.nix
@@ -1,0 +1,12 @@
+{
+  fetchzip,
+  writeShellScriptBin,
+  httplz,
+}:
+let
+  frontend = fetchzip {
+    url = "https://github.com/yeicor-3d/yet-another-cad-viewer/releases/download/v0.8.11/frontend.zip";
+    hash = "sha256-J57XPF3/1i/DlHYaR06xw6mTWAu8HW7wxFLRtJGl23w=";
+  };
+in
+writeShellScriptBin "yacv-frontend" "${httplz}/bin/httplz ${frontend}"


### PR DESCRIPTION
Init [yacv](https://github.com/yeicor-3d/yet-another-cad-viewer)

> A CAD viewer capable of displaying OCP models (CadQuery/Build123d) in a web
> browser.

Additionally adds a script `yacv-frontend` for hosting the frontend locally. Uses the
precomipled frontend because I do not know how to work with yarn in nix yet.
