### PR TITLE
build123d: v0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/python/build123d/default.nix
+++ b/pkgs/python/build123d/default.nix
@@ -19,12 +19,12 @@
 }:
 let
   pname = "build123d";
-  version = "0.7.0";
+  version = "0.8.0";
   src = fetchFromGitHub {
     owner = "gumyr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-21H4WexV6NbeLZdX1Ht5+opaOQrd9Tff1nH874r/agI=";
+    hash = "sha256-yhTMMuYCmrdWbc4+7mUm1m1q6qGqQDn0tN5te/EPQac=";
   };
 in
 buildPythonPackage {
@@ -64,5 +64,7 @@ buildPythonPackage {
     # Overly strict test
     "test_version"
   ];
+
+  pythonRelaxDeps = [ "numpy" ];
 
 }


### PR DESCRIPTION
Bump build123d from version 0.7.0 to 0.8.0. Relax deps on numpy as supplying numpy v2 right now is a hassle and everything seems to work find on v1.