### PR TITLE
Initialize vscode-ocp-cad-viewer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727802920,
-        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {

--- a/pkgs/opencascade-occt/default.nix
+++ b/pkgs/opencascade-occt/default.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableFreeimage [ freeimage ]
     ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Cocoa;
 
+  NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
+
   cmakeFlags =
     [ "-D BUILD_RELEASE_DISABLE_EXCEPTIONS=OFF" ]
     ++ lib.optional enableFreeimage [

--- a/pkgs/python/ocp-tessellate/default.nix
+++ b/pkgs/python/ocp-tessellate/default.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  webcolors,
+  numpy,
+  cachetools,
+  imagesize,
+  pytestCheckHook,
+  build123d,
+  cadquery,
+}:
+let
+  version = "3.0.8";
+  owner = "bernhard-42";
+  repo = "ocp-tessellate";
+  rev = "v${version}";
+in
+
+buildPythonPackage {
+  pname = "ocp_tesselate";
+  inherit version;
+
+  src = fetchFromGitHub {
+    inherit owner repo rev;
+    hash = "sha256-wnWQoX++JRDqiaXvZ38Fm5tLrToDvk6qD3pMuyXYB+U=";
+  };
+
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    build123d
+    cadquery
+  ];
+
+  pytestFlagsArray = [
+    "pytests"
+  ];
+
+  # Not sure why these fail
+  disabledTests = [
+    "TestConvertMixedCompounds"
+  ];
+
+  dependencies = [
+    webcolors
+    numpy
+    cachetools
+    imagesize
+  ];
+
+}

--- a/pkgs/python/overlay.nix
+++ b/pkgs/python/overlay.nix
@@ -15,6 +15,7 @@ final: prev: {
   libclang = prev.libclang.override { llvmPackages = llvmPackages_15; };
   nlopt = final.callPackage ./nlopt { };
   ocp = final.callPackage ./ocp { inherit ocp; };
+  ocp-tessellate = final.callPackage ./ocp-tessellate { };
   ocpsvg = final.callPackage ./ocpsvg { };
   py-lib3mf = final.callPackage ./py-lib3mf { };
   qtconsole = final.callPackage ./qtconsole { };

--- a/pkgs/python/overlay.nix
+++ b/pkgs/python/overlay.nix
@@ -23,5 +23,6 @@ final: prev: {
   spyder-kernels = final.callPackage ./spyder-kernels { };
   svgpathtools = final.callPackage ./svgpathtools { };
   trianglesolver = final.callPackage ./trianglesolver { };
+  vscode-ocp-cad-viewer = final.callPackage ./vscode-ocp-cad-viewer { };
   yacv-server = final.callPackage ./yacv-server { };
 }

--- a/pkgs/python/vscode-ocp-cad-viewer/default.nix
+++ b/pkgs/python/vscode-ocp-cad-viewer/default.nix
@@ -1,0 +1,64 @@
+{
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  pytestCheckHook,
+  ocp-tessellate,
+  requests,
+  ipykernel,
+  orjson,
+  websockets,
+  pyaml,
+  flask,
+  flask-sock,
+  click,
+  build123d,
+}:
+let
+  version = "2.6.1";
+  owner = "bernhard-42";
+  repo = "vscode-ocp-cad-viewer";
+  rev = "v${version}";
+in
+
+buildPythonPackage {
+  pname = "ocp_vscode";
+  inherit version;
+
+  src = fetchFromGitHub {
+    inherit owner repo rev;
+    hash = "sha256-Rf5MgyE25TeUQwRee/icW/FOEwuwznRIHA5p3ZrUaaM=";
+  };
+
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    ocp-tessellate
+    requests
+    ipykernel
+    orjson
+    websockets
+    pyaml
+    flask
+    flask-sock
+    click
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    build123d
+  ];
+
+  # The tests attempt to write to home directory...
+  doCheck = false;
+
+  # TODO:
+  # Too lazy to write a patch for this
+  # https://github.com/bernhard-42/ocp-tessellate/issues/7
+  pythonRelaxDeps = [
+    "ocp-tessellate"
+  ];
+
+}


### PR DESCRIPTION
Initializes [vscode-ocp-cad-viewer](https://github.com/bernhard-42/vscode-ocp-cad-viewer) at version 2.6.1.

Notes:

- The test suite for vscode-ocp-cad-viewer is disabled as all of the tests tried to write to `$HOME`.
- `ocp-tessellate` has a borked `pyproject.toml` which causes nix to think its version `3.0.7`. If upstream doesn't fix quickly I'll add a patch I guess
- had to add `-fpermissive` to fix compilation issues ala https://github.com/NixOS/nixpkgs/commit/79663cf113edf0e41165c12cf36ddb45f2329c1a